### PR TITLE
Minor change in StoreFrontTest

### DIFF
--- a/src/com/toasternetwork/inventory/tests/StoreFrontTest.java
+++ b/src/com/toasternetwork/inventory/tests/StoreFrontTest.java
@@ -41,7 +41,7 @@ class StoreFrontTest {
 	@Test
 	void getStoreId() {
 		TestHelper.print(testName, "Checking store ID is not zero");
-		assertTrue(sf.getStoreId() != 0);
+		assertTrue(sf.getStoreId() > 0);
 		TestHelper.complete();
 	}
 }


### PR DESCRIPTION
Quick change from != to > for testing for positive Store IDs. This could happen if memory of the store ID has changed.